### PR TITLE
add licences

### DIFF
--- a/Dockerfile.api.multistage
+++ b/Dockerfile.api.multistage
@@ -11,7 +11,6 @@ COPY rules /usr/src/app/rules
 COPY templates /usr/src/app/templates
 COPY ui /usr/src/app/ui
 COPY pom.xml /usr/src/app
-COPY license.txt /usr/src/app
 
 USER root
 RUN chown -R quarkus /usr/src/app

--- a/Dockerfile.api.multistage
+++ b/Dockerfile.api.multistage
@@ -11,6 +11,7 @@ COPY rules /usr/src/app/rules
 COPY templates /usr/src/app/templates
 COPY ui /usr/src/app/ui
 COPY pom.xml /usr/src/app
+COPY license.txt /usr/src/app
 
 USER root
 RUN chown -R quarkus /usr/src/app

--- a/Dockerfile.apisigner.multistage
+++ b/Dockerfile.apisigner.multistage
@@ -11,7 +11,6 @@ COPY rules /usr/src/app/rules
 COPY templates /usr/src/app/templates
 COPY ui /usr/src/app/ui
 COPY pom.xml /usr/src/app
-COPY license.txt /usr/src/app
 
 USER root
 RUN chown -R quarkus /usr/src/app

--- a/Dockerfile.apisigner.multistage
+++ b/Dockerfile.apisigner.multistage
@@ -11,6 +11,7 @@ COPY rules /usr/src/app/rules
 COPY templates /usr/src/app/templates
 COPY ui /usr/src/app/ui
 COPY pom.xml /usr/src/app
+COPY license.txt /usr/src/app
 
 USER root
 RUN chown -R quarkus /usr/src/app

--- a/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/representations/idm/ErrorRepresentation.java
+++ b/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/representations/idm/ErrorRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apicore.representations.idm;
 
 public class ErrorRepresentation {

--- a/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/resources/ApiApplication.java
+++ b/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/resources/ApiApplication.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apicore.resources;
 
 import javax.ws.rs.ApplicationPath;

--- a/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/resources/ApiErrorHandler.java
+++ b/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/resources/ApiErrorHandler.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apicore.resources;
 
 import org.jboss.logging.Logger;

--- a/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/utils/MediaTypeMatcher.java
+++ b/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/utils/MediaTypeMatcher.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apicore.utils;
 
 import javax.ws.rs.core.HttpHeaders;

--- a/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/utils/ResourceUtils.java
+++ b/api-core/src/main/java/org/openublpe/xmlbuilder/apicore/utils/ResourceUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources.utils;
 
 public class ResourceUtils {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/bootstrap/ServerBootstrap.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/bootstrap/ServerBootstrap.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.bootstrap;
 
 import io.quarkus.runtime.StartupEvent;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/AbstractRsaKeyProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/AbstractRsaKeyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.openublpe.xmlbuilder.apisigner.keys.component.ComponentModel;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/AbstractRsaKeyProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/AbstractRsaKeyProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.openublpe.xmlbuilder.apisigner.keys.component.ComponentModel;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/Attributes.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/Attributes.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.openublpe.xmlbuilder.apisigner.keys.provider.ProviderConfigProperty;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/DefaultKeyManager.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/DefaultKeyManager.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.jboss.logging.Logger;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/FailsafeRsaKeyProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/FailsafeRsaKeyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.jboss.logging.Logger;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/GeneratedRsaKeyProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/GeneratedRsaKeyProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.jboss.logging.Logger;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/ImportedRsaKeyProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/ImportedRsaKeyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.keycloak.common.util.KeyUtils;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/ImportedRsaKeyProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/ImportedRsaKeyProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.keycloak.common.util.CertificateUtils;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/JavaKeystoreKeyProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/JavaKeystoreKeyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.jboss.logging.Logger;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/JavaKeystoreKeyProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/JavaKeystoreKeyProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.jboss.logging.Logger;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/KeyMetadata.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/KeyMetadata.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 public class KeyMetadata {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/KeyProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/KeyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/KeyProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/KeyProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.openublpe.xmlbuilder.apisigner.keys.component.ComponentFactory;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/PublicKeyLoader.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/PublicKeyLoader.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import java.security.PublicKey;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/PublicKeyStorageProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/PublicKeyStorageProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import java.security.PublicKey;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/PublicKeyStorageUtils.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/PublicKeyStorageUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 public class PublicKeyStorageUtils {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/RsaKeyMetadata.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/RsaKeyMetadata.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import java.security.PublicKey;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/RsaKeyProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/RsaKeyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.keycloak.jose.jws.AlgorithmType;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/RsaKeyProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/RsaKeyProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys;
 
 import org.keycloak.jose.jws.AlgorithmType;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ComponentFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ComponentFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component;
 
 import org.openublpe.xmlbuilder.apisigner.keys.provider.ConfiguredProvider;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ComponentModel.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ComponentModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component;
 
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ComponentValidationException.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ComponentValidationException.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component;
 
 public class ComponentValidationException extends RuntimeException {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ConfiguredComponent.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/ConfiguredComponent.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component;
 
 import org.openublpe.xmlbuilder.apisigner.keys.provider.ConfiguredProvider;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/PrioritizedComponentModel.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/PrioritizedComponentModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component;
 
 import java.util.Comparator;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/ComponentProviderLiteral.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/ComponentProviderLiteral.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component.utils;
 
 import org.openublpe.xmlbuilder.apisigner.keys.qualifiers.ComponentProviderType;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/ComponentUtil.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/ComponentUtil.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component.utils;
 
 import org.openublpe.xmlbuilder.apisigner.keys.component.ComponentFactory;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/DefaultComponentUtil.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/DefaultComponentUtil.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component.utils;
 
 import org.openublpe.xmlbuilder.apisigner.keys.KeyProviderFactory;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/RsaKeyProviderLiteral.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/component/utils/RsaKeyProviderLiteral.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.component.utils;
 
 import org.openublpe.xmlbuilder.apisigner.keys.qualifiers.RsaKeyProviderType;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ConfigurationValidationHelper.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ConfigurationValidationHelper.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.provider;
 
 import org.openublpe.xmlbuilder.apisigner.keys.component.ComponentModel;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ConfiguredProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ConfiguredProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.provider;
 
 import java.util.List;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ProviderConfigProperty.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ProviderConfigProperty.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.provider;
 
 import java.util.Arrays;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ProviderConfigurationBuilder.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ProviderConfigurationBuilder.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.provider;
 
 import java.util.Arrays;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ProviderFactory.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/provider/ProviderFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.provider;
 
 /**

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/qualifiers/ComponentProviderType.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/qualifiers/ComponentProviderType.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.qualifiers;
 
 import javax.inject.Qualifier;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/qualifiers/RsaKeyProviderType.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/qualifiers/RsaKeyProviderType.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.qualifiers;
 
 import javax.inject.Qualifier;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/qualifiers/RsaKeyType.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/keys/qualifiers/RsaKeyType.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.keys.qualifiers;
 
 import org.openublpe.xmlbuilder.apisigner.keys.GeneratedRsaKeyProviderFactory;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/managers/OrganizationManager.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/managers/OrganizationManager.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.managers;
 
 import org.openublpe.xmlbuilder.apisigner.keys.KeyProvider;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ComponentProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ComponentProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 import org.openublpe.xmlbuilder.apisigner.keys.component.ComponentModel;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/KeyManager.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/KeyManager.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 import org.openublpe.xmlbuilder.apisigner.keys.RsaKeyMetadata;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/Model.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/Model.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 public interface Model {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ModelException.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ModelException.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 public class ModelException extends Exception {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ModelRuntimeException.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ModelRuntimeException.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 public class ModelRuntimeException extends RuntimeException{

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ModelType.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/ModelType.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 public enum ModelType {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/OrganizationModel.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/OrganizationModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 public interface OrganizationModel extends Model {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/OrganizationProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/OrganizationProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 import java.util.List;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/OrganizationType.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/OrganizationType.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 public enum OrganizationType {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/SearchResultsModel.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/SearchResultsModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models;
 
 import java.util.ArrayList;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/JpaComponentProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/JpaComponentProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa;
 
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/JpaModel.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/JpaModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa;
 
 public interface JpaModel<T> {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/JpaOrganizationProvider.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/JpaOrganizationProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa;
 
 import io.quarkus.hibernate.orm.panache.PanacheQuery;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/OrganizationAdapter.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/OrganizationAdapter.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa;
 
 import org.openublpe.xmlbuilder.apisigner.models.ModelType;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/entities/ComponentConfigEntity.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/entities/ComponentConfigEntity.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa.entities;
 
 import javax.persistence.Access;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/entities/ComponentEntity.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/entities/ComponentEntity.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa.entities;
 
 import javax.persistence.Access;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/entities/OrganizationEntity.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/jpa/entities/OrganizationEntity.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.jpa.entities;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/utils/DefaultKeyProviders.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/utils/DefaultKeyProviders.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.utils;
 
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/utils/ModelToRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/utils/ModelToRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.utils;
 
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/utils/RepresentationToModel.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/models/utils/RepresentationToModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.models.utils;
 
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ComponentRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ComponentRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 import org.keycloak.common.util.MultivaluedHashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ComponentTypeRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ComponentTypeRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 import java.util.HashMap;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ConfigPropertyRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ConfigPropertyRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 import java.util.List;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ErrorRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ErrorRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 public class ErrorRepresentation {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/OrganizationRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/OrganizationRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 public class OrganizationRepresentation {

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/SearchResultsRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/SearchResultsRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 import java.util.ArrayList;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ServerInfoRepresentation.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/representations/idm/ServerInfoRepresentation.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.representations.idm;
 
 import java.util.List;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationsDocumentsResource.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationsDocumentsResource.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import org.openublpe.xmlbuilder.api.resources.utils.ResourceUtils;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationsResource.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationsResource.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import org.keycloak.common.util.PemUtils;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/resources/ServerInfoAdminResource.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/resources/ServerInfoAdminResource.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import org.openublpe.xmlbuilder.apisigner.keys.KeyProvider;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/xml/XMLSigner.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/xml/XMLSigner.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.xml;
 
 import org.w3c.dom.Document;

--- a/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/xml/XmlSignatureHelper.java
+++ b/api-signer/src/main/java/org/openublpe/xmlbuilder/apisigner/xml/XmlSignatureHelper.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.xml;
 
 import org.w3c.dom.Document;

--- a/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/NativeOrganizationDocumentsResourceIT.java
+++ b/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/NativeOrganizationDocumentsResourceIT.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import io.quarkus.test.junit.NativeImageTest;

--- a/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/NativeOrganizationsResourceIT.java
+++ b/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/NativeOrganizationsResourceIT.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import io.quarkus.test.junit.NativeImageTest;

--- a/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationDocumentsResourceITSunat.java
+++ b/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationDocumentsResourceITSunat.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationDocumentsResourceTest.java
+++ b/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationDocumentsResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationsResourceTest.java
+++ b/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/OrganizationsResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/UBLNamespaces.java
+++ b/api-signer/src/test/java/org/openublpe/xmlbuilder/apisigner/resources/UBLNamespaces.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.apisigner.resources;
 
 import org.custommonkey.xmlunit.NamespaceContext;

--- a/api/src/main/java/org/openublpe/xmlbuilder/api/resources/DocumentsResource.java
+++ b/api/src/main/java/org/openublpe/xmlbuilder/api/resources/DocumentsResource.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources;
 
 import org.openublpe.xmlbuilder.api.resources.utils.ResourceUtils;

--- a/api/src/main/java/org/openublpe/xmlbuilder/api/resources/ValidationExceptionHandler.java
+++ b/api/src/main/java/org/openublpe/xmlbuilder/api/resources/ValidationExceptionHandler.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources;
 
 import org.jboss.resteasy.api.validation.ResteasyConstraintViolation;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/DocumentsResourceTest.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/DocumentsResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/EnrichDocumentsResourceTest.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/EnrichDocumentsResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/NativeDocumentsResourceIT.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/NativeDocumentsResourceIT.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources;
 
 import io.quarkus.test.junit.NativeImageTest;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/AbstractCertTest.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/AbstractCertTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources.utils;
 
 import org.openublpe.xmlbuilder.inputdata.AbstractInputDataTest;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/CertificateDetails.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/CertificateDetails.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources.utils;
 
 import java.security.PrivateKey;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/CertificateDetailsFactory.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/CertificateDetailsFactory.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources.utils;
 
 import java.io.IOException;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/XMLSigner.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/XMLSigner.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources.utils;
 
 import org.w3c.dom.Document;

--- a/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/XMLUtils.java
+++ b/api/src/test/java/org/openublpe/xmlbuilder/api/resources/utils/XMLUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.api.resources.utils;
 
 import org.w3c.dom.Document;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 import java.util.Optional;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog1.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog1.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 import java.util.Optional;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog10.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog10.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog10 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog16.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog16.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog16 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog19.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog19.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum  Catalog19 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog5.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog5.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog5 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog6.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog6.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog6 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog7.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog7.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog7 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog7_1.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog7_1.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog7_1 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog9.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/Catalog9.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs;
 
 public enum Catalog9 implements Catalog {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/constraints/CatalogConstraint.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/constraints/CatalogConstraint.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs.constraints;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/constraints/CatalogValidator.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/catalogs/constraints/CatalogValidator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs.constraints;
 
 

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/common/ClienteInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/common/ClienteInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.common;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog6;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/common/FirmanteInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/common/FirmanteInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.common;
 
 import javax.validation.constraints.NotNull;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/common/ProveedorInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/common/ProveedorInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.common;
 
 import javax.validation.constraints.NotBlank;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/DetalleInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/DetalleInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.standard;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/DocumentInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/DocumentInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.standard;
 
 import org.openublpe.xmlbuilder.core.models.input.common.ClienteInputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/invoice/InvoiceInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/invoice/InvoiceInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.standard.invoice;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DocumentInputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/note/NoteInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/note/NoteInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.standard.note;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DocumentInputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/note/creditNote/CreditNoteInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/note/creditNote/CreditNoteInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.standard.note.creditNote;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog9;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/note/debitNote/DebitNoteInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/standard/note/debitNote/DebitNoteInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.standard.note.debitNote;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog10;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/sunat/SummaryDocumentInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/sunat/SummaryDocumentInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.sunat;
 
 import org.openublpe.xmlbuilder.core.models.input.common.FirmanteInputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/sunat/SummaryDocumentLineInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/sunat/SummaryDocumentLineInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.sunat;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/sunat/VoidedDocumentInputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/input/sunat/VoidedDocumentInputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.input.sunat;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/common/ClienteOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/common/ClienteOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.common;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog6;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/common/FirmanteOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/common/FirmanteOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.common;
 
 import javax.validation.constraints.NotNull;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/common/ProveedorOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/common/ProveedorOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.common;
 
 import javax.validation.constraints.NotBlank;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/DetalleOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/DetalleOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 import javax.validation.Valid;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/DetallePrecioReferenciaOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/DetallePrecioReferenciaOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog16;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/DocumentOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/DocumentOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 import org.openublpe.xmlbuilder.core.models.output.common.ClienteOutputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoDetalladoICBOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoDetalladoICBOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 public class ImpuestoDetalladoICBOutputModel extends ImpuestoOutputModel {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoDetalladoIGVOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoDetalladoIGVOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog5;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoTotalICBOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoTotalICBOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 public class ImpuestoTotalICBOutputModel extends ImpuestoOutputModel {

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoTotalIGVOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/ImpuestoTotalIGVOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard;
 
 import javax.validation.constraints.Min;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/invoice/InvoiceOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/invoice/InvoiceOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/note/NoteOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/note/NoteOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard.note;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/note/creditNote/CreditNoteOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/note/creditNote/CreditNoteOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard.note.creditNote;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog9;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/note/debitNote/DebitNoteOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/standard/note/debitNote/DebitNoteOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.standard.note.debitNote;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog10;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/ImpuestoTotalResumenDiarioOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/ImpuestoTotalResumenDiarioOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.sunat;
 
 import org.openublpe.xmlbuilder.core.models.output.standard.ImpuestoOutputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/SummaryDocumentLineOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/SummaryDocumentLineOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.sunat;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/SummaryDocumentOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/SummaryDocumentOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.sunat;
 
 import org.openublpe.xmlbuilder.core.models.output.common.FirmanteOutputModel;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/TotalValorVentaOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/TotalValorVentaOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.sunat;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7_1;

--- a/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/VoidedDocumentOutputModel.java
+++ b/core/src/main/java/org/openublpe/xmlbuilder/core/models/output/sunat/VoidedDocumentOutputModel.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.output.sunat;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/core/src/test/java/org/openublpe/xmlbuilder/core/models/catalogs/constraints/CatalogValidatorTest.java
+++ b/core/src/test/java/org/openublpe/xmlbuilder/core/models/catalogs/constraints/CatalogValidatorTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.core.models.catalogs.constraints;
 
 import org.junit.jupiter.api.Test;

--- a/extensions/bouncycastle/deployment/src/main/java/org/openublpe/quarkus/bouncycastle/deployment/BouncycastleProcessor.java
+++ b/extensions/bouncycastle/deployment/src/main/java/org/openublpe/quarkus/bouncycastle/deployment/BouncycastleProcessor.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.bouncycastle.deployment;
 
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/extensions/freemarker/deployment/src/main/java/org/openublpe/quarkus/freemarker/deployment/FreemarkerNativeImageProcessor.java
+++ b/extensions/freemarker/deployment/src/main/java/org/openublpe/quarkus/freemarker/deployment/FreemarkerNativeImageProcessor.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker.deployment;
 
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/extensions/freemarker/deployment/src/main/java/org/openublpe/quarkus/freemarker/deployment/FreemarkerProcessor.java
+++ b/extensions/freemarker/deployment/src/main/java/org/openublpe/quarkus/freemarker/deployment/FreemarkerProcessor.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker.deployment;
 
 import freemarker.ext.jython.JythonModel;

--- a/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/ConfigurationHolder.java
+++ b/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/ConfigurationHolder.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker;
 
 import freemarker.template.Configuration;

--- a/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/ConfigurationProvider.java
+++ b/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/ConfigurationProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker;
 
 import freemarker.template.Configuration;

--- a/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/FreemarkerBuildConfig.java
+++ b/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/FreemarkerBuildConfig.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker;
 
 import io.quarkus.runtime.annotations.ConfigItem;

--- a/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/FreemarkerConfigurationRecorder.java
+++ b/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/FreemarkerConfigurationRecorder.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker;
 
 import io.quarkus.runtime.annotations.Recorder;

--- a/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/QuarkusPathLocationScanner.java
+++ b/extensions/freemarker/runtime/src/main/java/org/openublpe/quarkus/freemarker/QuarkusPathLocationScanner.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.freemarker;
 
 public final class QuarkusPathLocationScanner {

--- a/extensions/keycloak/deployment/src/main/java/org/openublpe/quarkus/keycloak/deployment/KeycloakProcessor.java
+++ b/extensions/keycloak/deployment/src/main/java/org/openublpe/quarkus/keycloak/deployment/KeycloakProcessor.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.quarkus.keycloak.deployment;
 
 import io.quarkus.deployment.annotations.BuildProducer;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/AbstractInputDataTest.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/AbstractInputDataTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/AbstractInvoiceInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/AbstractInvoiceInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/CreditNoteInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/CreditNoteInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.note.creditNote.CreditNoteInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/DebitNoteInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/DebitNoteInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.note.debitNote.DebitNoteInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/GeneralData.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/GeneralData.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog6;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/InputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/InputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import java.util.Optional;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/InvoiceInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/InvoiceInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/SummaryDocumentInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/SummaryDocumentInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.input.sunat.SummaryDocumentInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/VoidedDocumentInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/VoidedDocumentInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator;
 
 import org.openublpe.xmlbuilder.core.models.input.sunat.VoidedDocumentInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/creditNote/CreditNote_SimpleInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/creditNote/CreditNote_SimpleInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.creditNote;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/debitNote/DebitNote_SimpleInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/debitNote/DebitNote_SimpleInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.debitNote;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/HomologacionUtils.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/HomologacionUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog5;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso10_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso10_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso11_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso11_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso1_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso1_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso2_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso2_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso3_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso3_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso4_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso4_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso5_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso5_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso6_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso6_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso7_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso7_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso8_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso8_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso9_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo1/Caso9_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo1;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso12_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso12_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso13_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso13_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso14_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso14_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso15_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso15_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso16_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso16_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso17_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso17_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso18_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso18_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso19_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso19_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso20_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso20_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso21_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso21_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso22_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo2/Caso22_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo2;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso23_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso23_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso24_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso24_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso25_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso25_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso26_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso26_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso27_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso27_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso28_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso28_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso29_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso29_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso30_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso30_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso31_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo3/Caso31_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo3;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso32_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso32_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso33_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso33_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso34_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso34_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso35_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso35_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso36_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso36_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso37_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso37_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso38_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso38_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso39_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso39_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso40_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso40_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso41_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso41_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso42_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo4/Caso42_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo4;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso52_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso52_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso53_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso53_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso54_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso54_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso55_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso55_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso56_InvoiceGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso56_InvoiceGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso57_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso57_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso58_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso58_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso59_CreditNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso59_CreditNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.invoice.InvoiceInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso60_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso60_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso61_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso61_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso62_DebitNoteGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/homologacion/grupo8/Caso62_DebitNoteGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.homologacion.grupo8;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_ComplexInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_ComplexInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_ExoneradaOnerosaInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_ExoneradaOnerosaInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaNoOnerosaConICBInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaNoOnerosaConICBInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaNoOnerosaInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaNoOnerosaInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaOnerosaConICBInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaOnerosaConICBInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaOnerosaInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_GravadaOnerosaInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_InafectoNoOnerosaInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_InafectoNoOnerosaInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_InafectoOnerosaInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_InafectoOnerosaInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog7;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_SimpleInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/invoice/Invoice_SimpleInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.invoice;
 
 import org.openublpe.xmlbuilder.core.models.input.standard.DetalleInputModel;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/summaryDocument/SummaryDocument_SimpleInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/summaryDocument/SummaryDocument_SimpleInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.summaryDocument;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/voidedDocument/VoidedDocument_SimpleInputGenerator.java
+++ b/input-test-data/src/main/java/org/openublpe/xmlbuilder/inputdata/generator/voidedDocument/VoidedDocument_SimpleInputGenerator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.inputdata.generator.voidedDocument;
 
 import org.openublpe.xmlbuilder.core.models.catalogs.Catalog1;

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,14 @@
+Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+and other contributors as indicated by the @author tags.
+
+Licensed under the Eclipse Public License - v 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.eclipse.org/legal/epl-2.0/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
 
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+
+        <license.dir>${basedir}</license.dir>
     </properties>
 
     <dependencyManagement>
@@ -147,6 +149,46 @@
         <module>ui</module>
     </modules>
 
+    <build>
+        <plugins>
+            <!-- License information -->
+            <plugin>
+                <groupId>com.mycila.maven-license-plugin</groupId>
+                <artifactId>maven-license-plugin</artifactId>
+                <version>1.10.b1</version>
+                <configuration>
+                    <header>license.txt</header>
+                    <properties>
+                        <project>
+                            ${project.name}
+                        </project>
+                        <founder>${project.organization.name}</founder>
+                        <year>${project.inceptionYear}</year>
+                        <website>${founder-website}</website>
+                    </properties>
+                    <includes>
+                        <include>src/main/java/**</include>
+                        <include>src/test/java/**</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>licenses</artifactId>
+                        <version>1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>sunat</id>

--- a/pom.xml
+++ b/pom.xml
@@ -149,46 +149,6 @@
         <module>ui</module>
     </modules>
 
-    <build>
-        <plugins>
-            <!-- License information -->
-            <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
-                <version>1.10.b1</version>
-                <configuration>
-                    <header>license.txt</header>
-                    <properties>
-                        <project>
-                            ${project.name}
-                        </project>
-                        <founder>${project.organization.name}</founder>
-                        <year>${project.inceptionYear}</year>
-                        <website>${founder-website}</website>
-                    </properties>
-                    <includes>
-                        <include>src/main/java/**</include>
-                        <include>src/test/java/**</include>
-                    </includes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.mycila</groupId>
-                        <artifactId>licenses</artifactId>
-                        <version>1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>sunat</id>
@@ -206,6 +166,50 @@
                                 <exclude>**/*Test.java</exclude>
                             </excludes>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>license</id>
+            <build>
+                <plugins>
+                    <!-- License information -->
+                    <!--mvn license:format -Plicense-->
+                    <plugin>
+                        <groupId>com.mycila.maven-license-plugin</groupId>
+                        <artifactId>maven-license-plugin</artifactId>
+                        <version>1.10.b1</version>
+                        <configuration>
+                            <header>license.txt</header>
+                            <properties>
+                                <project>
+                                    ${project.name}
+                                </project>
+                                <founder>${project.organization.name}</founder>
+                                <year>${project.inceptionYear}</year>
+                                <website>${founder-website}</website>
+                            </properties>
+                            <includes>
+                                <include>src/main/java/**</include>
+                                <include>src/test/java/**</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                                <phase>process-sources</phase>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.mycila</groupId>
+                                <artifactId>licenses</artifactId>
+                                <version>1</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/rules/src/main/java/org/openublpe/xmlbuilder/rules/UBLConstants.java
+++ b/rules/src/main/java/org/openublpe/xmlbuilder/rules/UBLConstants.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.rules;
 
 public class UBLConstants {

--- a/rules/src/main/java/org/openublpe/xmlbuilder/rules/executors/KieExecutor.java
+++ b/rules/src/main/java/org/openublpe/xmlbuilder/rules/executors/KieExecutor.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.rules.executors;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;

--- a/rules/src/main/java/org/openublpe/xmlbuilder/rules/utils/DateUtils.java
+++ b/rules/src/main/java/org/openublpe/xmlbuilder/rules/utils/DateUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.rules.utils;
 
 import java.text.SimpleDateFormat;

--- a/rules/src/main/java/org/openublpe/xmlbuilder/rules/utils/NumberUtils.java
+++ b/rules/src/main/java/org/openublpe/xmlbuilder/rules/utils/NumberUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.rules.utils;
 
 import java.math.BigDecimal;

--- a/rules/src/main/java/org/openublpe/xmlbuilder/rules/utils/UBLUtils.java
+++ b/rules/src/main/java/org/openublpe/xmlbuilder/rules/utils/UBLUtils.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.rules.utils;
 
 import java.util.regex.Pattern;

--- a/rules/src/test/java/org/openublpe/xmlbuilder/rules/executors/KieExecutorTest.java
+++ b/rules/src/test/java/org/openublpe/xmlbuilder/rules/executors/KieExecutorTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.rules.executors;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/templates/src/main/java/org/openublpe/xmlbuilder/templates/FreemarkerConstants.java
+++ b/templates/src/main/java/org/openublpe/xmlbuilder/templates/FreemarkerConstants.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.templates;
 
 public class FreemarkerConstants {

--- a/templates/src/main/java/org/openublpe/xmlbuilder/templates/FreemarkerGlobalConfiguration.java
+++ b/templates/src/main/java/org/openublpe/xmlbuilder/templates/FreemarkerGlobalConfiguration.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.templates;
 
 import freemarker.template.Configuration;

--- a/templates/src/main/java/org/openublpe/xmlbuilder/templates/executors/FreemarkerExecutor.java
+++ b/templates/src/main/java/org/openublpe/xmlbuilder/templates/executors/FreemarkerExecutor.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2019 Project OpenUBL, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Eclipse Public License - v 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openublpe.xmlbuilder.templates.executors;
 
 import freemarker.template.Template;

--- a/ui/test.json
+++ b/ui/test.json
@@ -1,0 +1,16 @@
+[
+    {
+        "attributeFilter": {
+            "key": "key1",
+            "operation": "equal",
+            "value": "1"
+        }
+    },
+    {
+        "attributeFilter": {
+            "key": "key2",
+            "operation": "in",
+            "value": "2,3,4"
+        }
+    }
+]


### PR DESCRIPTION
Agrega un profile llamado `license` que puede ser utilizado para poner la licensia en la cabecera de cada archivo.

El comando para agregar las licencias es: `mvn license:format -Plicense`